### PR TITLE
fix run_tests bash syntax error

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,7 +4,7 @@
 rep=$(curl -s --unix-socket /var/run/docker.sock http://ping > /dev/null)
 status=$?
 
-if [ $status == 7 ]; then
+if [ $status -eq 7 ]; then
     echo 'docker is not running - test will not be executed'
     exit 1
 fi


### PR DESCRIPTION
fix error

## Proposed changes

CircleCI mentioned a bash syntax error in run_tests.sh (`run_tests.sh: 7: [: 0: unexpected operator` e.g. in [this job](https://app.circleci.com/pipelines/github/orchestracities/ngsi-timeseries-api/439/workflows/221b0ba3-4c3f-4348-87a7-10810119ff79/jobs/2157))

Fixed the bash syntax here.

## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask. We're here to help! This is simply a reminder of what we are going
to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [CLA][cla]
- [ ] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in
      downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc...




[cla]: https://raw.githubusercontent.com/orchestracities/ngsi-timeseries-api/master/individual-cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
