### PR TITLE
Replace borg connection manager with thread safe db pool

### DIFF
--- a/src/translators/base_translator.py
+++ b/src/translators/base_translator.py
@@ -17,7 +17,7 @@ class BaseTranslator(object):
         self.port = port
         self.db_name = db_name
 
-    def __enter__(self):
+    def __enter__(self, connection, query):
         self.setup()
         return self
 

--- a/src/translators/crate.py
+++ b/src/translators/crate.py
@@ -43,15 +43,15 @@ CRATE_TO_NGSI['string_array'] = 'Array'
 class CrateTranslator(sql_translator.SQLTranslator):
     NGSI_TO_SQL = NGSI_TO_SQL
 
-    def __init__(self, host, port=4200, db_name="ngsi-tsdb"):
-        super(CrateTranslator, self).__init__(host, port, db_name)
+    def __init__(self, connection, query , host, port=4200, db_name="ngsi-tsdb"):
+        super(CrateTranslator, self).__init__(host, connection, query , port, db_name)
         self.logger = logging.getLogger(__name__)
         self.dbCacheName = 'crate'
         self.ccm = None
         self.connection = None
         self.cursor = None
 
-    def setup(self):
+    def setup(self, connection, query):
         url = "{}:{}".format(self.host, self.port)
         self.ccm = ConnectionManager()
         self.connection = self.ccm.get_connection('crate')

--- a/src/translators/sql_translator.py
+++ b/src/translators/sql_translator.py
@@ -15,7 +15,8 @@ from uuid import uuid4
 
 from cache.factory import get_cache, is_cache_available
 from translators.insert_splitter import to_insert_batches
-from utils.connection_manager import Borg
+from utils.connection_manager import ConnectionManager
+
 # NGSI TYPES
 # Based on Orion output because official docs don't say much about these :(
 NGSI_DATETIME = 'DateTime'
@@ -117,9 +118,9 @@ class SQLTranslator(base_translator.BaseTranslator):
 
     start_time = None
 
-    def __init__(self, host, port, db_name):
+    def __init__(self, host, port, db_name, connection, query):
         super(SQLTranslator, self).__init__(host, port, db_name)
-        qcm = QueryCacheManager()
+        qcm = QueryCacheManager(connection, query)
         self.cache = qcm.get_query_cache()
         self.default_ttl = None
         if self.cache:
@@ -1781,11 +1782,11 @@ class SQLTranslator(base_translator.BaseTranslator):
                                     exc_info=True)
 
 
-class QueryCacheManager(Borg):
+class QueryCacheManager(ConnectionManager):
     cache = None
 
-    def __init__(self):
-        super(QueryCacheManager, self).__init__()
+    def __init__(self, connection, query):
+        super(QueryCacheManager, self ).__init__( connection, query)
         if is_cache_available() and self.cache is None:
             try:
                 self.cache = get_cache()

--- a/src/utils/connection_manager.py
+++ b/src/utils/connection_manager.py
@@ -1,25 +1,67 @@
-class Borg:
-    _shared_state = {}
+from crate import client
+from crate.client.sqlalchemy.dialect import CrateDialect
+import sqlalchemy.pool as pool
+import argparse
+from sqlalchemy import create_engine
 
-    def __init__(self):
-        self.__dict__ = self._shared_state
+class ConnectionManager():
+    """
+    Invoke queries to database in parallel.
+    """
 
+    def __init__(self, connection, query):
+        self.connection = connection
+        self.query = query
 
-class ConnectionManager(Borg):
+    def querydb_dbapi(connection, query):
+        """
+        Submit query to database.
+        """
+        cursor = connection.cursor()
+        cursor.execute(query)
+        result = cursor.fetchone()
+        cursor.close()
+        return result
 
-    connection = {}
-
-    def __init__(self):
-        Borg.__init__(self)
+    def querydb_sqlalchemy(connection, query):
+        """
+        Submit query to database.
+        """
+        result = connection.execute(query).fetchone()
+        return result
 
     def set_connection(self, db, connection):
         self.connection[db] = connection
 
-    def get_connection(self, db):
-        try:
-            return self.connection[db]
-        except KeyError as e:
-            return None
+    def get_connection(connection):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--driver')
+        parser.add_argument('--pool', action='store_true')
+        args = parser.parse_args()
 
-    def reset_connection(self, db):
-        self.connection[db] = None
+        if args.driver == "dbapi":
+        # Use DBAPI driver.
+            if args.pool:
+                query = querydb_dbapi
+                # Use a connection pool matching the number of workers.
+                engine  = create_engine("crate://localhost:4200", connect_args={"pool_size": 10})
+            else:
+                # Don't use a pool.
+                engine = create_engine("crate://localhost:4200")
+        elif args.driver == "sqlalchemy":
+            if args.pool:
+                query = querydb_sqlalchemy
+                # Use a connection pool matching the number of workers.
+                engine = create_engine("crate://localhost:4200", connect_args={"pool_size": 10})
+            else:
+                # Don't use a pool.
+                engine = create_engine("crate://localhost:4200")
+            connection = engine.connect()
+        else:
+            raise ValueError("Unknown value for --driver: Use 'dbapi' or 'sqlalchemy'.")
+
+    # Invoke some database queries.
+    query = 'SELECT 1;'
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Proposed changes

Does changes as per [references ](https://github.com/crate/crate-python/issues/393) 
Fix for [Issue ](https://github.com/orchestracities/ngsi-timeseries-api/issues/397)
## Types of changes

What types of changes does your code introduce to the project: _Put
an `x` in the boxes that apply_

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
      functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask. We're here to help! This is simply a reminder of what we are going
to look for before merging your code._

- [ x ] I have read the [CONTRIBUTING][contrib] doc
- [ x ] I have signed the [CLA][cla]
- [ ] I have added tests that prove my fix is effective or that my
      feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in
      downstream modules

## Further comments

- Replaced "borg" connection used in file connection_manager.py with  `CrateDB's SQLAlchemy dialect`

- Also, took references from [discussion](https://github.com/crate/crate-python/issues/393#issuecomment-738147528)

- used `create_engine` connection.


[cla]: https://raw.githubusercontent.com/orchestracities/ngsi-timeseries-api/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/smartsdk/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
