### PR TITLE
fix issues with ci worfklow for docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=ref,event=branch
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
@@ -68,7 +67,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=ref,event=branch
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
             type=semver,pattern={{major}}
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'push'
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -44,7 +44,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   quantumleap-pg-init:
@@ -69,7 +69,7 @@ jobs:
             type=semver,pattern={{major}}
       -
         name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.event_name != 'push'
         uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -79,6 +79,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: timescale-container
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && github.event_name != 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,11 +29,10 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=edge,branch=master
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=ref,event=branch
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
@@ -66,11 +65,10 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=edge,branch=master
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=ref,event=branch
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 ### Continuous Integration
 
+- Fix docker image generation issues (#624)
+
 ### Documentation
 
 - Fix links in pr template (#620)


### PR DESCRIPTION
## Proposed changes

The github action is not correctly generating tags for the docker images. e.g. instead of generating 0.8.3 tag, generated release-0.8.3, and didn't tag it also as "latest".

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [CLA][cla]
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run **all** the existing tests locally (not just those related to my feature) and there are no errors
- [x] After the last push to the PR branch, I have run the lint script locally and there are no changes to the code base
- [x] I have updated the [RELEASE NOTES][release]
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A



[cla]: https://raw.githubusercontent.com/orchestracities/ngsi-timeseries-api/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
[release]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/RELEASE_NOTES.md
    "QuantumLeap Release Notes"
