### PR TITLE
fix #636

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@
 
 - Fix links in pr template (#620)
 - Mention running tests locally as well as linting in PR template (#621)
+- Fix variable names for CrateDB authentication (#636)
 
 ### Technical debt
 

--- a/docs/manuals/admin/configuration.md
+++ b/docs/manuals/admin/configuration.md
@@ -8,8 +8,8 @@ To configure QuantumLeap you can use the following environment variables:
 | -------------------|-------------------------|
 | `CRATE_HOST`       | CrateDB Host            |
 | `CRATE_PORT`       | CrateDB Port            |
-| `CRATE_DB_USERNAME`| CrateDB Username        |
-| `CRATE_DB_PASSWORD`| CrateDB Password        |
+| `CRATE_DB_USER`    | CrateDB Username        |
+| `CRATE_DB_PASS`    | CrateDB Password        |
 | `CRATE_BACKOFF_FACTOR`   | The time between the retries to connect crate is controlled by `CRATE_BACKOFF_FACTOR`. Default value is `0.0` |
 | `DEFAULT_LIMIT`    | Max number of rows a query can retrieve |
 | `KEEP_RAW_ENTITY`  | Whether to store original entity data |
@@ -175,7 +175,7 @@ To configure QuantumLeap you can use the following environment variables:
   defined by `CRATE_BACKOFF_FACTOR`. The Maximum value of `CRATE_BACKOFF_FACTOR`
   is: `120`. The default value is `0.0`.
 
-- `CRATE_DB_USERNAME`. Only needed if password authentication is used at the Crate
+- `CRATE_DB_USER`. Only needed if password authentication is used at the Crate
   database. Please ensure the specified user has cluster wide `DML`, `DDL` and
   `DQL` permissions. Example user creation in CrateDB: `CREATE USER quantumleap
   WITH (password = 'a_secret_password'); GRANT DML,DDL,DQL TO quantumleap;`. For


### PR DESCRIPTION
## Proposed changes

The names of the envs for CrateDB-authentication are wrong in the documentation.
Debug-logs revealed that QL is expecting:

CRATE_DB_USER instead of CRATE_DB_USERNAME
and
CRATE_DB_PASS instead of CRATE_DB_PASSWORD
## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (update of libraries or other dependences)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [CLA][cla]
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run **all** the existing tests locally (not just those related to my feature) and there are no errors
- [ ] After the last push to the PR branch, I have run the lint script locally and there are no changes to the code base
- [x] I have updated the [RELEASE NOTES][release]
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A




[cla]: https://raw.githubusercontent.com/orchestracities/ngsi-timeseries-api/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
[release]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/RELEASE_NOTES.md
    "QuantumLeap Release Notes"
