### PR TITLE
resolved error handling in sql_translator #697

### DIFF
--- a/src/translators/sql_translator.py
+++ b/src/translators/sql_translator.py
@@ -362,15 +362,13 @@ class SQLTranslator(base_translator.BaseTranslator):
         stmt = f"insert into {table_name} ({col_list}) values ({placeholders})"
         try:
             start_time = datetime.now()
+            res_list = []
 
             for batch in to_insert_batches(rows):
                 res = self.cursor.executemany(stmt, batch)
-                # new version of crate does not bomb anymore when
-                # something goes wrong in multi entries
-                # simply it returns -2 for each row that have an issue
-                # TODO: improve error handling.
-                # using batches, we don't need to fail the whole set
-                # but only failing batches.
+                res_list.append(res)
+        
+            for res in res_list:
                 if isinstance(res, list):
                     for i in range(len(res)):
                         if res[i]['rowcount'] < 0:


### PR DESCRIPTION
## Proposed changes
#697 improve error handling in sql_translator.py

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance (update of libraries or other dependences)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [CLA][cla]
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run **all** the existing tests locally (not just those related to my feature) and there are no errors
- [x] After the last push to the PR branch, I have run the lint script locally and there are no changes to the code base
- [x] I have updated the [RELEASE NOTES][release]
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...




[cla]: https://raw.githubusercontent.com/orchestracities/ngsi-timeseries-api/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
[release]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/RELEASE_NOTES.md
    "QuantumLeap Release Notes"
