### PR TITLE
Release 1.0.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # QuantumLeap Release Notes
 
-## 0.9.0-dev
+## 1.0.0
 
 ### New features
 

--- a/specification/quantumleap.yml
+++ b/specification/quantumleap.yml
@@ -1,7 +1,7 @@
 swagger: '2.0'  # For 3.0 see (https://github.com/zalando/connexion/issues/420)
 info:
   title: "QuantumLeap API"
-  version: "0.9.0-dev"      # we'll keep it aligned with QL version
+  version: "1.0.0"      # we'll keep it aligned with QL version
 host: "localhost:8668"  # it'll run in the same container, hence localhost.
 produces:
   - text/plain
@@ -87,7 +87,7 @@ definitions:
         items:
           type: string
     example:
-      entities: 
+      entities:
         - id: Kitchen
           type: Room
       attrs:
@@ -119,7 +119,7 @@ definitions:
     example, if aggrPeriod is day, each value of course may not correspond
     to original measurements but rather the aggregate of measurements in
     each day."
-    
+
   IndexedValues:
     type: object
     properties:
@@ -1370,7 +1370,7 @@ paths:
         - $ref: '#/parameters/geometry'
         - $ref: '#/parameters/coords'
         - $ref: '#/parameters/idPattern'
-        
+
         # In Header...
         - $ref: '#/parameters/fiware-Service'
         - $ref: '#/parameters/fiware-ServicePath'

--- a/src/reporter/tests/test_version.py
+++ b/src/reporter/tests/test_version.py
@@ -7,5 +7,5 @@ def test_version():
     r = requests.get('{}'.format(version_url))
     assert r.status_code == 200, r.text
     assert r.json() == {
-        "version": "0.9.0-dev"
+        "version": "1.0.0"
     }

--- a/src/reporter/version.py
+++ b/src/reporter/version.py
@@ -2,5 +2,5 @@
 
 def version():
     return {
-        'version': '0.9.0-dev'
+        'version': '1.0.0'
     }


### PR DESCRIPTION
With this PR, we releases QuantumLeap version 1.0.0.

### New features

- Removed subscription API (#493)
- Replaced geocoder with [geopy](https://geopy.readthedocs.io/en/stable/) (#610)
- Bumped pillow from 8.4.0 to 9.0.0
- Aligned missing Fiware-servicePath behaviour with the one of Orion
  Context Broker (#564). This is a breaking change! Before no value for
  Fiware-servicePath was interpreted as python None, from now on, None
  will be replaced with /. This affects only users that manually injected
  data, since Orion, assume / when no servicePath is passed.
- Added more test cases for Aggregation (#499)
- fix translator initialization
- List Addix among adopters (#649)
- Replaced string with the constants (#650)
- Added idPattern ain query parameter (#648)
- Remove duplicate code in src/reporter/tests/test_timescale_types.py (#657)
- Removed comments on line no.462 and 467 in sql_translator.py (#659)
- Added logs in src/wq/ql/notify.py (#656)
- Added logs in src/wq/core/task.py (#662)
- Replaced entity with getter (#652)
- Resolved TODO in Dockerfile (#680)
- Resolved TODO at src/reporter/tests/test_timescale_types.py (#667)
- Resolved TODO at src/transaltors/sql_transaltor.py (#694)
- Resolved TODO at src/translator/sql_translator.py (#686)
- Resolved TODO at src/translators/sql_translator.py#L768.py (#683)
- Resolved TODO at src/reporter/tests/utils.py (#692)
- Added error handling in src/wq/ql/notify.py (#673)
- NGSI-LD tenant header (#664, #669)

### Bug fixes

- Fix issues with integration tests and backward compatibility tests
- Fix for linter failures (#670)
- Fix for issue broken docker image (#674)
- Fix for broken link in README.md (#688)
- Fix for incorrect notation in file (#725)

### Continuous Integration

- Improve github action for docker images (#624)
- Add caching to docker image builds (#626)
- Update CI to use CrateDB 4.6.7 and Orion 3.3.1
- Add maintenance type to pr template

### Documentation

- Fix links in pr template (#620)
- Mention running tests locally as well as linting in PR template (#621)
- Fix variable names for CrateDB authentication (#636)

### Technical debt

- Upgrade Python deps to fix security vulnerabilities, make the Docker
  image build again and restore a working dev env on Apple silicon. (#737) 