### PR TITLE
Fix to return OK/200 and an empty result set when no data found

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
 
 ### Bug fixes
 
+- Fix to return OK/200 and an empty result set when no data found (#720)
+
 ### Continuous Integration
 
 ### Documentation

--- a/src/reporter/delete.py
+++ b/src/reporter/delete.py
@@ -21,11 +21,8 @@ def delete_entity(entity_id, type_=None, from_date=None, to_date=None):
 
     logging.getLogger(__name__).info("deleted {} entities".format(deleted))
     if deleted == 0:
-        r = {
-            "error": "Not Found",
-            "description": "No records were found for such query."
-        }
-        return r, 404
+        r = []
+        return r, 200
 
     if deleted > 0:
         return '{} records successfully deleted.'.format(deleted), 204
@@ -53,11 +50,8 @@ def delete_entities(entity_type, from_date=None, to_date=None,
         logging.getLogger(__name__).info(
             "deleted {} entities of type {}".format(deleted, entity_type))
         if deleted == 0:
-            r = {
-                "error": "Not Found",
-                "description": "No records were found for such query."
-            }
-            return r, 404
+            r = []
+            return r, 200
 
         if deleted > 0:
             return '{} records successfully deleted.'.format(deleted), 204

--- a/src/reporter/op.py
+++ b/src/reporter/op.py
@@ -70,12 +70,9 @@ def query():
             logging.getLogger(__name__).info("Query processed successfully")
             res.append(entities[0])
         else:
-            r = {
-                "error": "Not Found",
-                "description": "No records were found for such query."
-            }
+            r = []
             logging.getLogger(__name__).info("No value found for query")
-            return r, 404
+            return r, 200
     return res, 200
 
 

--- a/src/reporter/query_1T1E1A.py
+++ b/src/reporter/query_1T1E1A.py
@@ -93,12 +93,9 @@ def query_1T1E1A(attr_name,   # In Path
         logging.getLogger(__name__).info("Query processed successfully")
         return res
 
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200
 
 
 def query_1T1E1A_value(*args, **kwargs):

--- a/src/reporter/query_1T1ENA.py
+++ b/src/reporter/query_1T1ENA.py
@@ -109,12 +109,9 @@ def query_1T1ENA(entity_id,   # In Path
             "usage of id and type rather than entityId and entityType from version 0.9")
         return res
 
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200
 
 
 def query_1T1ENA_value(*args, **kwargs):

--- a/src/reporter/query_1TNE1A.py
+++ b/src/reporter/query_1TNE1A.py
@@ -108,12 +108,9 @@ def query_1TNE1A(attr_name,   # In Path
             "usage of id and type rather than entityId and entityType from version 0.9")
         return res
 
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200
 
 
 def _prepare_response(entities, attr_name, entity_type, entity_ids,

--- a/src/reporter/query_1TNENA.py
+++ b/src/reporter/query_1TNENA.py
@@ -111,12 +111,9 @@ def query_1TNENA(entity_type=None,  # In Path
             "usage of id and type rather than entityId and entityType from version 0.9")
         return res
 
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200
 
 
 def _prepare_response(entities, attrs, entity_type, entity_ids,

--- a/src/reporter/query_NTNE.py
+++ b/src/reporter/query_NTNE.py
@@ -62,9 +62,6 @@ def query_NTNE(limit=10000,
         logging.getLogger(__name__).info("Query processed successfully")
         return res
 
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200

--- a/src/reporter/query_NTNE1A.py
+++ b/src/reporter/query_NTNE1A.py
@@ -146,12 +146,9 @@ def query_NTNE1A(attr_name,  # In Path
         logging.warning(
             "usage of id and type rather than entityId and entityType from version 0.9")
         return res
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200
 
 
 def query_NTNE1A_value(*args, **kwargs):

--- a/src/reporter/query_NTNENA.py
+++ b/src/reporter/query_NTNENA.py
@@ -159,12 +159,9 @@ def query_NTNENA(id_=None,  # In Query
         logging.getLogger(__name__).info("AggrMethod cannot be applied")
         return r, 404
 
-    r = {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    r = []
     logging.getLogger(__name__).info("No value found for query")
-    return r, 404
+    return r, 200
 
 
 def query_NTNENA_value(*args, **kwargs):

--- a/src/reporter/tests/test_1T1E1A.py
+++ b/src/reporter/tests/test_1T1E1A.py
@@ -437,11 +437,8 @@ def test_not_found(service):
     h = {'Fiware-Service': service}
 
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_1T1ENA.py
+++ b/src/reporter/tests/test_1T1ENA.py
@@ -642,8 +642,5 @@ def test_not_found(service):
     h = {'Fiware-Service': service}
 
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []

--- a/src/reporter/tests/test_1TNE1A.py
+++ b/src/reporter/tests/test_1TNE1A.py
@@ -152,11 +152,8 @@ def idPattern_not_found(service):
     h = {'Fiware-Service': service}
 
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)
@@ -281,11 +278,8 @@ def test_not_found(service):
     h = {'Fiware-Service': service}
 
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_1TNENA.py
+++ b/src/reporter/tests/test_1TNENA.py
@@ -159,11 +159,8 @@ def idPattern_not_found(service):
     }
     h = {'Fiware-Service': service}
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)
@@ -319,11 +316,8 @@ def test_not_found(service):
     }
     h = {'Fiware-Service': service}
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_Headers.py
+++ b/src/reporter/tests/test_Headers.py
@@ -77,9 +77,8 @@ def test_for_invalid_headers(notification):
     get_url = "{}/entities/Room0".format(QL_URL)
     res_get = requests.get(get_url, headers=HEADERS_INVALID)
 
-    assert res_get.status_code == 404
+    assert res_get.status_code == 200
+    assert res_get.json() == []
 
-    exp_result = {
-        'description': 'No records were found for such query.',
-        'error': 'Not Found'}
+    exp_result = []
     assert res_get.json() == exp_result

--- a/src/reporter/tests/test_NTNE.py
+++ b/src/reporter/tests/test_NTNE.py
@@ -65,11 +65,8 @@ def test_not_found(service):
     }
     h = {'Fiware-Service': service}
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)
@@ -79,11 +76,8 @@ def idpattern_not_found(service):
     }
     h = {'Fiware-Service': service}
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_NTNE1A.py
+++ b/src/reporter/tests/test_NTNE1A.py
@@ -113,11 +113,8 @@ def idPattern_not_found(service, reporter_dataset):
     }
     h = {'Fiware-Service': service}
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)
@@ -308,11 +305,8 @@ def test_not_found(service, reporter_dataset):
     }
     h = {'Fiware-Service': service}
     r = requests.get(query_url(), params=query_params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_NTNENA.py
+++ b/src/reporter/tests/test_NTNENA.py
@@ -301,11 +301,8 @@ def idPattern_not_found(service, reporter_dataset):
         'idPattern': 'NotThere'
     }
     r = query(params=query_params, service=service)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)
@@ -985,11 +982,8 @@ def test_not_found(service, reporter_dataset):
         'type': 'NotThere'
     }
     r = query(params=query_params, service=service)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_delete.py
+++ b/src/reporter/tests/test_delete.py
@@ -67,7 +67,8 @@ def test_delete_entity(service):
 
     # Values are gone
     r = requests.get(url, params=params, headers=h)
-    assert r.status_code == 404, r.text
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
     # But not for other entities of same type
     url = '{}/entities/{}'.format(QL_URL, entity_type + '1')
@@ -111,7 +112,8 @@ def test_delete_entities(service):
     for e in range(2):
         url = '{}/entities/{}'.format(QL_URL, '{}{}'.format(entity_type, e))
         r = requests.get(url, params=params, headers=h)
-        assert r.status_code == 404, r.text
+        assert r.status_code == 200, r.text
+        assert r.json() == []
 
     # But not for entities of other types
     url = '{}/entities/{}'.format(QL_URL, 'Room1')
@@ -136,11 +138,8 @@ def test_not_found(service):
     url = '{}/entities/{}'.format(QL_URL, entity_type + '0')
 
     r = requests.delete(url, params=params, headers=h)
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", [
@@ -281,7 +280,8 @@ def test_delete_347():
     time.sleep(SLEEP_TIME)
     url = '{}/entities/{}'.format(QL_URL, '{}{}'.format(entity_type, 'un3'))
     r = requests.get(url, params=params, headers=h)
-    assert r.status_code == 404, r.text
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 def test_delete_different_servicepaths():
@@ -366,7 +366,8 @@ def test_delete_different_servicepaths():
     time.sleep(SLEEP_TIME)
     url = '{}/entities/{}'.format(QL_URL, 'un3')
     r = requests.get(url, params=params, headers=h)
-    assert r.status_code == 404, r.text
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 def test_drop_table():
@@ -448,4 +449,5 @@ def test_drop_table():
     time.sleep(SLEEP_TIME)
     url = '{}/entities/{}'.format(QL_URL, 'un3')
     r = requests.get(url, params=params, headers=h)
-    assert r.status_code == 404, r.text
+    assert r.status_code == 200, r.text
+    assert r.json() == []

--- a/src/reporter/tests/test_geo_queries_1t1e.py
+++ b/src/reporter/tests/test_geo_queries_1t1e.py
@@ -179,8 +179,8 @@ def test_disjoint_with_overlapping_polygon(service, setup_entities, query_fn):
         'coords': '-0.1,0.1;-0.1,1;1.1,1;1.1,0.1;-0.1,0.1'
     }
 
-    query_fn(service, entity_1['id'], query_params, expected_status_code=404)
-    query_fn(service, entity_2['id'], query_params, expected_status_code=404)
+    query_fn(service, entity_1['id'], query_params, expected_status_code=200)
+    query_fn(service, entity_2['id'], query_params, expected_status_code=200)
 
 
 @pytest.mark.parametrize('query_fn', [

--- a/src/reporter/tests/test_geo_query_1tne1a.py
+++ b/src/reporter/tests/test_geo_query_1tne1a.py
@@ -149,7 +149,7 @@ def test_disjoint_with_overlapping_polygon(service, setup_entities):
         'coords': '-0.1,0.1;-0.1,1;1.1,1;1.1,0.1;-0.1,0.1'
     }
 
-    query_1tne1a(service, query_params, expected_status_code=404)
+    query_1tne1a(service, query_params, expected_status_code=200)
 
 
 @pytest.mark.parametrize("service", services)

--- a/src/reporter/tests/test_notify.py
+++ b/src/reporter/tests/test_notify.py
@@ -514,7 +514,8 @@ def test_no_value_for_attributes(service, notification):
     # Give time for notification to be processed
     time.sleep(SLEEP_TIME)
     res_get = requests.get(url_new, headers=notify_header(service))
-    assert res_get.status_code == 404
+    assert res_get.status_code == 200
+    assert res_get.json() == []
     # entity with missing value string
     notification['data'][0] = {
         'id': '299531',
@@ -532,7 +533,8 @@ def test_no_value_for_attributes(service, notification):
     # Give time for notification to be processed
     time.sleep(SLEEP_TIME)
     res_get = requests.get(url_new, headers=query_header(service))
-    assert res_get.status_code == 404
+    assert res_get.status_code == 200
+    assert res_get.json() == []
     # entity has both valid and empty attributes
     notification['data'][0] = {
         'id': '299531',
@@ -573,7 +575,8 @@ def test_no_value_no_type_for_attributes(service, notification):
     # Give time for notification to be processed
     time.sleep(SLEEP_TIME)
     res_get = requests.get(url_new, headers=query_header(service))
-    assert res_get.status_code == 404
+    assert res_get.status_code == 200
+    assert res_get.json() == []
     # Get value of attribute having value
     get_url_new = "{}/entities/Room1/attrs/pressure/value".format(QL_URL)
     url_new = '{}'.format(get_url_new)

--- a/src/reporter/tests/test_op.py
+++ b/src/reporter/tests/test_op.py
@@ -141,11 +141,8 @@ def test_query_not_found(service, reporter_dataset):
     r = requests.post('{}'.format(query_url),
                       data=json.dumps(body),
                       headers=headers(service))
-    assert r.status_code == 404, r.text
-    assert r.json() == {
-        "error": "Not Found",
-        "description": "No records were found for such query."
-    }
+    assert r.status_code == 200, r.text
+    assert r.json() == []
 
 
 @pytest.mark.parametrize("service", services)


### PR DESCRIPTION
## Proposed changes

Removed 404 NOT FOUND in when no data found for query and returned 200 OK with empty set. Fix for issue #720 .

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance (update of libraries or other dependences)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING][contrib] doc
- [x] I have signed the [CLA][cla]
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run **all** the existing tests locally (not just those related to my feature) and there are no errors
- [x] After the last push to the PR branch, I have run the lint script locally and there are no changes to the code base
- [x] I have updated the [RELEASE NOTES][release]
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules




[cla]: https://raw.githubusercontent.com/orchestracities/ngsi-timeseries-api/master/individual_cla.pdf
    "Martel Open Source Software Individual Contributor License Agreement"
[contrib]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/CONTRIBUTING.md
    "Contributing to QuantumLeap"
[release]: https://github.com/orchestracities/ngsi-timeseries-api/blob/master/RELEASE_NOTES.md
    "QuantumLeap Release Notes"
